### PR TITLE
paramiko 2.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "paramiko" %}
-{% set version = "2.8.1" %}
+{% set version = "2.12.0" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_val = "85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438" %}
+{% set hash_val = "376885c05c5d6aa6e1f4608aac2a6b5b0548b1add40274477324605903d9cd49" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index f24b973..634b07d 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "paramiko" %}
-{% set version = "2.8.1" %}
+{% set version = "2.12.0" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_val = "85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438" %}
+{% set hash_val = "376885c05c5d6aa6e1f4608aac2a6b5b0548b1add40274477324605903d9cd49" %}
 
 package:
   name: {{ name }}

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/paramiko/paramiko//releases
[Diff between the latest and previous upstream releases](https://github.com/paramiko/paramiko//compare/2.8.1...2.12.0)
License: https://github.com/paramiko/paramiko//blob/master/LICENSE
Requirements:
 * setup.cfg:  https://github.com/paramiko/paramiko//blob/2.12.0/setup.cfg
 * setup.py:  https://github.com/paramiko/paramiko//blob/2.12.0/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.12.0
 * Release on PyPi:
    * version: 2.12.0
    * date: 2022-11-04T22:33:03
* [PyPi history](https://pypi.org/project/paramiko/#history)
 * Popularity: 
    * 3 months downloads: 301254.0
    * All time:  2373415 downloads -  paramiko  2.12.0  SSH2 protocol library  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/paramiko/paramiko//tree/2.12.0 exists
2. - [ ] The upstream url error:
    http://www.paramiko.org/
    302
The home url must have HTTPS!
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/paramiko/paramiko//tree/2.12.0
    200
5. - [ ] Additional research
    https://github.com/paramiko/paramiko//issues
    200
6. - [x] `dev_url` is present
    https://github.com/paramiko/paramiko/
7. - [ ] `doc_url` error:
    http://docs.paramiko.org/
    302
The doc_url must have HTTPS!
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present
16. - [x] License: LGPL-2.1-or-later
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier        |
|:------------------|
| LGPL-2.1-or-later |

17. - [x] license_family LGPL is present
</details>

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/paramiko/paramiko//releases
[Diff between the latest and previous upstream releases](https://github.com/paramiko/paramiko//compare/2.8.1...2.12.0)
License: https://github.com/paramiko/paramiko//blob/master/LICENSE
Requirements:
 * setup.cfg:  https://github.com/paramiko/paramiko//blob/2.12.0/setup.cfg
 * setup.py:  https://github.com/paramiko/paramiko//blob/2.12.0/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.12.0
 * Release on PyPi:
    * version: 2.12.0
    * date: 2022-11-04T22:33:03
* [PyPi history](https://pypi.org/project/paramiko/#history)
 * Popularity: 
    * 3 months downloads: 301254.0
    * All time:  2373511 downloads -  paramiko  2.12.0  SSH2 protocol library  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/paramiko/paramiko//tree/2.12.0 exists
2. - [ ] The upstream url error:
    http://www.paramiko.org/
    302
The home url must have HTTPS!
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/paramiko/paramiko//tree/2.12.0
    200
5. - [ ] Additional research
    https://github.com/paramiko/paramiko//issues
    200
6. - [x] `dev_url` is present
    https://github.com/paramiko/paramiko/
7. - [ ] `doc_url` error:
    http://docs.paramiko.org/
    302
The doc_url must have HTTPS!
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present
16. - [x] License: LGPL-2.1-or-later
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier        |
|:------------------|
| LGPL-2.1-or-later |

17. - [x] license_family LGPL is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/paramiko-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/paramiko-feedstock/tree/2.12.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/paramiko)
* [Diff between upstream and feature branch](https://github.com/conda-forge/paramiko-feedstock/compare/main...AnacondaRecipes:2.12.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/paramiko-feedstock/compare/master...AnacondaRecipes:2.12.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/paramiko-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.12.0 git@github.com:AnacondaRecipes/paramiko-feedstock.git
```
