### PR TITLE
paramiko 3.5.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,11 @@ requirements:
     - bcrypt >=3.2
     - cryptography >=3.3
     - pynacl >=1.5
+  run_constrained:
+    - pyasn1 >=0.1.7
+    - gssapi >=1.4.1   # [not win]
+    - pywin32 >=218  # [win]
+    - invoke >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,52 @@
 {% set name = "paramiko" %}
-{% set version = "2.8.1" %}
+{% set version = "3.5.0" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_val = "85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438" %}
+{% set hash_val = "ad11e540da4f55cedda52931f1a3f812a8238a7af7f62a60de538cd80bb28124" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
   {{ hash_type }}: {{ hash_val }}
 
 build:
+  skip: True  # [py<36]
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
-  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv --no-build-isolation
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - bcrypt >=3.1.3
-    - cryptography >=2.5
-    - pynacl >=1.0.1
+    - bcrypt >=3.2
+    - cryptography >=3.3
+    - pynacl >=1.5
 
 test:
   imports:
     - paramiko
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://www.paramiko.org/
+  home: https://www.paramiko.org/
   license_file: LICENSE
   license: LGPL-2.1-or-later
-  summary: 'SSH2 protocol library'
+  summary: SSH2 protocol library
+  description: |
+    A Python implementation of SSHv2
   license_family: LGPL
   dev_url: https://github.com/paramiko/paramiko/
-  doc_url: http://docs.paramiko.org/
+  doc_url: https://docs.paramiko.org/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
paramiko 3.5.0 (CVE-2023-48795 SSH Protocol (Terrapin))

**Destination channel:** Defaults

### Links

- [PKG-6075]
- dev_url:        https://github.com/paramiko/paramiko//tree/3.5.0
- conda_forge:    https://github.com/conda-forge/paramiko-feedstock
- pypi:           https://pypi.org/project/paramiko/3.5.0
- pypi inspector: https://inspector.pypi.io/project/paramiko/3.5.0

### Explanation of changes:

- new version number
- no `pytest`ing as `tests/conftest.py` requires `icecream` -- which we don't have


[PKG-6075]: https://anaconda.atlassian.net/browse/PKG-6075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ